### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/font.php
+++ b/syntax/font.php
@@ -75,7 +75,7 @@ class syntax_plugin_emphasis_font extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler    $handler The handler
      * @return array Data for the renderer
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $data['match'] = $match;
 
         switch($state) {
@@ -130,7 +130,7 @@ class syntax_plugin_emphasis_font extends DokuWiki_Syntax_Plugin {
      * @param array          $hdata    The data from the handler function
      * @return bool If rendering was successful.
      */
-    function render($mode, &$renderer, $hdata) {
+    function render($mode, Doku_Renderer $renderer, $hdata) {
         list($state, $data) = $hdata;
 
         if($mode == 'xhtml') {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.