### PR TITLE
Adjustment to ODT plugin branch 'redesign'.

### DIFF
--- a/syntax/font.php
+++ b/syntax/font.php
@@ -149,15 +149,18 @@ class syntax_plugin_emphasis_font extends DokuWiki_Syntax_Plugin {
             /** @var renderer_plugin_odt $renderer */
             switch ($state) {
                 case DOKU_LEXER_ENTER:
-                    $renderer->_odtSpanOpenUseCSSStyle ($data['colortype'].': '.$data['color'].';font-weight:bold;');
-                    break;
+                    if (!class_exists('ODTDocument')) {
+                        $renderer->_odtSpanOpenUseCSSStyle ($data['colortype'].': '.$data['color'].';font-weight:bold;');
+                    } else {
+                        $renderer->_odtSpanOpenUseCSS (NULL, 'class="plugin_emphasis" style="'.$data['colortype'].': '.$data['color'].';"');
+                    }
+                    return true;
 
                 case DOKU_LEXER_EXIT:
                     // Close the span.
                     $renderer->_odtSpanClose();
-                    break;
+                    return true;
             }
-            return true;
         }
         return false;
     }


### PR DESCRIPTION
As announced on the mailing list some adjustment for the ODT plugin branch 'redesign'.

The new code has the advantage that it uses the CSS definitions. So if the CSS definition changes, the exported ODT document will change also.